### PR TITLE
[백준] 1145 적어도 대부분의 배수

### DIFF
--- a/Baekjoon/완전탐색(Brute Force)/1145 적어도 대부분의 배수/HwangInGyu.java
+++ b/Baekjoon/완전탐색(Brute Force)/1145 적어도 대부분의 배수/HwangInGyu.java
@@ -17,9 +17,9 @@ public class HwangInGyu {
     }
 
     private static int getAlmostMultipleNumber(int[] arrOfNums) {
-        int cntOfBaesoo = 0;
         int number;
         for (number = 1; number <= 1000000; number++) {
+            int cntOfBaesoo = 0;
             for (int i = 0; i < arrOfNums.length; i++) {
                 if (number%arrOfNums[i] == 0) {
                     cntOfBaesoo++;
@@ -28,7 +28,6 @@ public class HwangInGyu {
                     }
                 }
             }
-            cntOfBaesoo = 0;
         }
 
         return -1;

--- a/Baekjoon/완전탐색(Brute Force)/1145 적어도 대부분의 배수/HwangInGyu.java
+++ b/Baekjoon/완전탐색(Brute Force)/1145 적어도 대부분의 배수/HwangInGyu.java
@@ -1,0 +1,36 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class HwangInGyu {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] numbers = br.readLine().split(" ");
+        int[] arrOfNums = new int[numbers.length];
+        for (int i = 0; i < arrOfNums.length; i++) {
+            arrOfNums[i] = Integer.parseInt(numbers[i]);
+        }
+
+
+        int number = getAlmostMultipleNumber(arrOfNums);
+        System.out.println(number);
+    }
+
+    private static int getAlmostMultipleNumber(int[] arrOfNums) {
+        int cntOfBaesoo = 0;
+        int number;
+        for (number = 1; number <= 1000000; number++) {
+            for (int i = 0; i < arrOfNums.length; i++) {
+                if (number%arrOfNums[i] == 0) {
+                    cntOfBaesoo++;
+                    if (cntOfBaesoo >= 3) {
+                        return number;
+                    }
+                }
+            }
+            cntOfBaesoo = 0;
+        }
+
+        return -1;
+    }
+}

--- a/Baekjoon/완전탐색(Brute Force)/1145 적어도 대부분의 배수/HwangInGyu.kt
+++ b/Baekjoon/완전탐색(Brute Force)/1145 적어도 대부분의 배수/HwangInGyu.kt
@@ -1,0 +1,24 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+fun main() = with(BufferedReader(InputStreamReader(System.`in`))) {
+    val numbers = readLine().split(" ").map { it.toInt() }
+    println(getAlmostMultipleNumber(numbers))
+}
+
+fun getAlmostMultipleNumber(numbers: List<Int>): Int {
+    for (multipleNumber in 1 until 1000000) {
+        var cntOfDividedNumber = 0
+        for (number in numbers) {
+            if (multipleNumber%number == 0) {
+                cntOfDividedNumber++
+                if (cntOfDividedNumber ==  3) {
+                    return multipleNumber
+                }
+            }
+        }
+        cntOfDividedNumber = 0
+    }
+
+    return -1
+}


### PR DESCRIPTION
### 문제 링크 📗
- https://www.acmicpc.net/problem/1145

### 코멘트 💡
5개의 수중에서 3개 이상의 배수면 그 수를 리턴해줘라.
숫자들의 최대곱은 100*100*100이므로 백만.
시간복잡도는 숫자의 범위가 n일 때, O(n^3).
