### PR TITLE
[백준] 슈퍼마리오

### DIFF
--- a/Baekjoon/완전탐색(Brute Force)/2851 슈퍼 마리오/HwangInGyu.java
+++ b/Baekjoon/완전탐색(Brute Force)/2851 슈퍼 마리오/HwangInGyu.java
@@ -1,0 +1,39 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class HwangInGyu {
+    static int cntOfMushrooms = 10;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int[] arrOfScores = new int[cntOfMushrooms];
+        for (int i = 0; i < cntOfMushrooms; i++) {
+            arrOfScores[i] = Integer.parseInt(br.readLine());
+        }
+
+        System.out.println(getNumberNearToHundred(arrOfScores,0,0));
+    }
+
+    private static int getNumberNearToHundred(int[] arrOfScores, int start, int end) {
+        if (end > cntOfMushrooms-1) {
+            return 0;
+        }
+
+        int sum1 = 0;
+        for (int i = start; i <= end; i++) {
+            sum1 += arrOfScores[i];
+        }
+        if (sum1 == 100) {
+            return sum1;
+        }
+
+        int sum2 = getNumberNearToHundred(arrOfScores, start, end+1);
+        if (Math.abs(100-sum1) < Math.abs(100-sum2)) {
+            return sum1;
+        } else if (Math.abs(100-sum1) > Math.abs(100-sum2)){
+            return sum2;
+        } else {
+            return sum1 > sum2 ? sum1 : sum2;
+        }
+    }
+}


### PR DESCRIPTION
### 문제 링크 📗
- https://www.acmicpc.net/problem/2851

### 코멘트 💡
완전탐색을 하는 문제.
조건에서 한번 먹지 않으면 끝까지 먹지 않는다는 조건을 착각해서 좀 오래 걸렸다.
안먹다가 먹는 건 되는 줄 알고 풀었는데 알고보니까 한 번 안먹으면 다시는 못먹는다.
시간복잡도는 시작점과 인덱스를 고르는 n^2에다가 고른 배열의 합을 구하는 n.
총 O(n^3)이 될 듯하다. 그래 봤자 100^3이라 100만밖에 안된다.
