### PR TITLE
[백준] 1057. 토너먼트

### DIFF
--- a/Baekjoon/완전탐색(Brute Force)/1057 토너먼트/Sanghoo.java
+++ b/Baekjoon/완전탐색(Brute Force)/1057 토너먼트/Sanghoo.java
@@ -1,0 +1,31 @@
+package BaekJoon.토너먼트_1057;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Sanghoo {
+
+    public static void main(String[] args) throws IOException {
+        try (final BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int N = Integer.parseInt(st.nextToken());
+            int kimNumber = Integer.parseInt(st.nextToken());
+            int limNumber = Integer.parseInt(st.nextToken());
+            int round = 1;
+
+            while (Math.abs(kimNumber - limNumber) >= 1) {
+                if (Math.abs(kimNumber - limNumber) == 1 && (kimNumber + limNumber) % 4 == 3) {
+                    break;
+                }
+                round++;
+                kimNumber = (kimNumber % 2 == 0) ? kimNumber / 2 : kimNumber / 2 + 1;
+                limNumber = (limNumber % 2 == 0) ? limNumber / 2 : limNumber / 2 + 1;
+            }
+
+            System.out.println(round);
+        }
+    }
+
+}


### PR DESCRIPTION
### 문제 링크 📗
- https://www.acmicpc.net/problem/1057
- 
### 코멘트 💡
너무 복잡하게 생각하고, 복잡한 규칙을 찾았네요.
정답 후 다른 사람 답안과 인규씨의 답안을 참고하니 아주 간단하게 풀 수 있더군요..ㅠ 😢

> 백준 서버 문제인진 모르겠지만 타 답안으로 제출해도 속도는 동일했습니다.. (연산도 줄었는데 말이죠..)
